### PR TITLE
meta(license): switch licensing scheme for the project

### DIFF
--- a/LICENSE-APACHE.md
+++ b/LICENSE-APACHE.md
@@ -1,0 +1,13 @@
+Copyright 2019 Entropic Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-PARITY.md
+++ b/LICENSE-PARITY.md
@@ -1,0 +1,71 @@
+# The Parity Public License 7.0.0
+
+Contributor: Kat Marchán <kzm@zkat.tech>
+
+Source Code: https://github.com/entropic-dev/ds
+
+## Purpose
+
+This license allows you to use and share this software for free, but you have to share software that builds on it alike.
+
+## Agreement
+
+In order to receive this license, you have to agree to its rules. Those rules are both obligations under that agreement and conditions to your license. Don't do anything with this software that triggers a rule you can't or won't follow.
+
+## Notices
+
+Make sure everyone who gets a copy of any part of this software from you, with or without changes, also gets the text of this license and the contributor and source code lines above.
+
+## Copyleft
+
+[Contribute](#contribute) software you develop, operate, or analyze with this software, including changes or additions to this software. When in doubt, [contribute](#contribute).
+
+## Prototypes
+
+You don't have to [contribute](#contribute) any change, addition, or other software that meets all these criteria:
+
+1.  You don't use it for more than thirty days.
+
+2.  You don't share it outside the team developing it, other than for non-production user testing.
+
+3.  You don't develop, operate, or analyze other software with it for anyone outside the team developing it.
+
+## Reverse Engineering
+
+You may use this software to operate and analyze software you can't [contribute](#contribute) in order to develop alternatives you can and do [contribute](#contribute).
+
+## Contribute
+
+To [contribute](#contribute) software:
+
+1.  Publish all source code for the software in the preferred form for making changes through a freely accessible distribution system widely used for similar source code so the contributor and others can find and copy it.
+
+2.  Make sure every part of the source code is available under this license or another license that allows everything this license does, such as [the Blue Oak Model License 1.0.0](https://blueoakcouncil.org/license/1.0.0), [the Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0.html), [the MIT license](https://spdx.org/licenses/MIT.html), or [the two-clause BSD license](https://spdx.org/licenses/BSD-2-Clause.html).
+
+3.  Take these steps within thirty days.
+
+4.  Note that this license does _not_ allow you to change the license terms for this software. You must follow [Notices](#notices).
+
+## Excuse
+
+You're excused for unknowingly breaking [Copyleft](#copyleft) if you [contribute](#contribute) as required, or stop doing anything requiring this license, within thirty days of learning you broke the rule. You're excused for unknowingly breaking [Notices](#notices) if you take all practical steps to comply within thirty days of learning you broke the rule.
+
+## Defense
+
+Don't make any legal claim against anyone accusing this software, with or without changes, alone or with other technology, of infringing any patent.
+
+## Copyright
+
+The contributor licenses you to do everything with this software that would otherwise infringe their copyright in it.
+
+## Patent
+
+The contributor licenses you to do everything with this software that would otherwise infringe any patents they can license or become able to license.
+
+## Reliability
+
+The contributor can't revoke this license.
+
+## No Liability
+
+**_As far as the law allows, this software comes as is, without any warranty or condition, and the contributor won't be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**

--- a/LICENSE-PATRON.md
+++ b/LICENSE-PATRON.md
@@ -1,0 +1,63 @@
+# Patron License
+
+Payment Platforms:
+
+- <https://opencollective.com/entropic>
+
+Participating Contributors:
+
+- Kat Marchán
+
+## Purpose
+
+This license gives everyone patronizing contributors to this software permission to ignore any noncommercial or copyleft rules of its free public license, while continuing to protect contributors from liability.
+
+## Acceptance
+
+In order to agree to these terms and receive a license, you must qualify under [Patrons](#patrons). The rules of these terms are both obligations under your agreement and conditions to your license. That agreement and your license continue only while you qualify as a patron. You must not do anything with this software that triggers a rule that you cannot or will not follow.
+
+## Patrons
+
+To accept these terms, you must be enrolled to make regular payments through any of the payment platforms pages listed above, in amounts qualifying you for a tier that includes a "patron license" or otherwise identifies a license under these terms as a reward.
+
+## Scope
+
+Except under [Seat](#seat) and [Applications](#applications), you may not sublicense or transfer any agreement or license under these terms to anyone else.
+
+## Seat
+
+If a legal entity, rather than an individual, accepts these terms, the entity may sublicense one individual employee or independent contractor at any given time. If the employee or contractor breaks any rule of these terms, the entity will stand directly responsible.
+
+## Applications
+
+If you combine this software with other software in a larger application, you may sublicense this software as part of your larger application, and allow further sublicensing in turn, under these rules:
+
+1. Your larger application must have significant additional content or functionality beyond that of this software, and end users must license your larger application primarily for that added content or functionality.
+
+2. You may not sublicense anyone to break any rule of the public license for this software for any changes of their own or any software besides your larger application.
+
+3. You may build, and sublicense for, as many larger applications as you like.
+
+## Copyright
+
+Each contributor licenses you to do everything with this software that would otherwise infringe that contributor's copyright in it.
+
+## Notices
+
+You must ensure that everyone who gets a copy of any part of this software from you, with or without changes, also gets the texts of both this license and the free public license for this software.
+
+## Excuse
+
+If anyone notifies you in writing that you have not complied with [Notices](#notices), you can keep your agreement and your license by taking all practical steps to comply within 30 days after the notice. If you do not do so, your agreement under these terms ends immediately, and your license ends with it.
+
+## Patent
+
+Each contributor licenses you to do everything with this software that would otherwise infringe any patent claims they can license or become able to license.
+
+## Reliability
+
+No contributor can revoke this license, but your license may end if you break any rule of these terms.
+
+## No Liability
+
+**_As far as the law allows, this software comes as is, without any warranty or condition, and no contributor will be liable to anyone for any damages related to this software or this license, under any kind of legal claim._**

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+Copyright 2019 Entropic Collaborators and Contributors
+
+This project is licensed under [the Parity License](LICENSE-PARITY.md). Third-party contributions are licensed under [Apache-2.0](LICENSE-APACHE.md) and belong to their respective authors.
+
+The Parity License is a copyleft license that, unlike the GPL family, allows you to license derivative and connected works under permissive licenses like MIT or Apache-2.0. It's free to use provided the work you do is freely available!
+
+For proprietary use, please [contact us](mailto:kzm@zkat.tech?subject=ds%20license), or just [sponsor us on OpenCollective](https://opencollective.com/entropic) under the appropriate tier to [acquire a proprietary-use license](LICENSE-PATRON.md)! This funding model helps us make our work sustainable and compensates us for the work it took to write this code!
+
+Please note that proprietary licenses will not be granted to any organization working with ICE or the military. The Entropic Collaborators reserve the right to deny licenses or license renewals.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,11 +1,12 @@
-The ds application
+All the code for the javascript code under `dstopic` is licensed as follows:
+
 Copyright (c) Entropic Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,8 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-Some parts of this application are derived from the tink application, with the
-following copyright:
+-----
+
+Some parts of the dstopic application are also derived from the tink
+application, with the following copyright:
 
 The tink application
 Copyright (c) npm, Inc. and Contributors.


### PR DESCRIPTION
Fixes: #18

After speaking with @ceejbot and @chrisdickinson, we agreed to put up a proposal for licensing based on the [Parity License](https://paritylicense.com) by @kemitchell.

This PR has the following effects:

1. All JavaScript source code, under `/dstopic`, will be licensed under Apache from now on.
2. The rest of the code, that is, all the Rust stuff, will be licensed under Parity for changes done by the core team.
3. Third-party PRs will have their changes licensed under Apache 2.0 for ease of relicensing.
4. Proprietary-use licenses will be made available either through subscriptions on OpenCollective, or by directly purchasing a license by emailing us.
5. Proprietary-use licenses will be immediately denied to any organization working with ICE or the military industrial complex.